### PR TITLE
Add extendPool and updateProject

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -4,7 +4,7 @@ skip-lint = false
 [programs.localnet]
 stockpile_v2 = "STKUaKniasuqrfer3XNbmrrc578pkL1XACdK8H3YPu8"
 [programs.devnet]
-stockpile_v2 = "HZR3KsVQAWDRALqtZJWssWXNu9GY9eMt5AQuo2QwSq32"
+stockpile_v2 = "STKUaKniasuqrfer3XNbmrrc578pkL1XACdK8H3YPu8"
 [programs.mainnet]
 stockpile_v2 = "STKUaKniasuqrfer3XNbmrrc578pkL1XACdK8H3YPu8"
 

--- a/programs/stockpile-v2/src/error.rs
+++ b/programs/stockpile-v2/src/error.rs
@@ -44,6 +44,9 @@ pub enum ProtocolError {
     #[msg("The end date has already passed")]
     EndDatePassed,
 
+    #[msg("Extend date is less than the current configured end date")]
+    ExtendDateInvalid,
+
     #[msg("An error occurred in the quadratic funding algorithm")]
     AlgorithmFailure,
 

--- a/programs/stockpile-v2/src/instructions/add_project.rs
+++ b/programs/stockpile-v2/src/instructions/add_project.rs
@@ -19,7 +19,7 @@ pub fn add_project(ctx: Context<AddProject>, _project_id: u64, _pool_id: u64) ->
     require!(pool_data.admins.contains(&payer_key), ProtocolError::NotAuthorized);
 
     // Check to make sure the pool is not closed
-    ctx.accounts.pool.is_active()?;
+    ctx.accounts.pool.can_fund()?;
 
     // Check to make sure the fundraiser isnt already in the pool
     if pool_data.project_shares.iter().any(|p| p.project_key == project_key) {

--- a/programs/stockpile-v2/src/instructions/contribute_with_vote.rs
+++ b/programs/stockpile-v2/src/instructions/contribute_with_vote.rs
@@ -119,9 +119,6 @@ pub struct ContributeWithVote<'info> {
     pub pyth_usdc_usd: UncheckedAccount<'info>,
     #[account( 
         mut,
-        realloc = 1024,
-        realloc::payer = payer,
-        realloc::zero = false,
         seeds = [
             Pool::SEED_PREFIX.as_bytes(),
             pool_id.to_le_bytes().as_ref(),

--- a/programs/stockpile-v2/src/instructions/extend_pool_duration.rs
+++ b/programs/stockpile-v2/src/instructions/extend_pool_duration.rs
@@ -1,0 +1,41 @@
+use anchor_lang::prelude::*;
+
+use crate::{state::pool::*, error::ProtocolError};
+
+/// Extends the duration of the pool by
+/// updating it's end field with a new timestamp.
+/// This instruction can only extend a pool, not shorten.
+pub fn extend_pool_duration(
+    ctx: Context<ExtendPool>,
+    _pool_id: u64,
+    new_end_date: u64,
+) -> Result<()> {
+    let pool = &mut ctx.accounts.pool;
+    let payer = &ctx.accounts.payer;
+
+    require!(pool.admins.contains(&payer.key()), ProtocolError::NotAuthorized);
+
+    pool.extend_pool_duration(new_end_date).expect("Failed to update end date.");
+    
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(
+    pool_id: u64,
+    _new_end_date: u64,
+)]
+pub struct ExtendPool<'info> {
+    #[account( 
+        mut,
+        seeds = [
+            Pool::SEED_PREFIX.as_bytes(),
+            pool_id.to_le_bytes().as_ref(),
+        ],
+        bump = pool.bump,
+    )]
+    pub pool: Account<'info, Pool>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}

--- a/programs/stockpile-v2/src/instructions/join_pool.rs
+++ b/programs/stockpile-v2/src/instructions/join_pool.rs
@@ -20,7 +20,7 @@ pub fn join_pool(ctx: Context<JoinPool>, _project_id: u64, _pool_id: u64) -> Res
     // Fundraiser access control check
     require!(project.admins.contains(&payer_key), ProtocolError::NotAuthorized);
 
-    pool.is_active()?;
+    pool.can_fund()?;
 
     // Check to make sure the fundraiser isnt already in the pool
     if pool_data.project_shares.iter().any(|p| p.project_key == project_key) {

--- a/programs/stockpile-v2/src/instructions/mod.rs
+++ b/programs/stockpile-v2/src/instructions/mod.rs
@@ -16,6 +16,8 @@ pub mod withdraw;
 pub mod withdraw_all;
 pub mod claim_payout;
 pub mod withdraw_funds_from_round;
+pub mod update_project;
+pub mod extend_pool_duration;
 
 pub use add_project::*;
 pub use close_milestone::*;
@@ -35,3 +37,5 @@ pub use withdraw::*;
 pub use withdraw_all::*;
 pub use claim_payout::*;
 pub use withdraw_funds_from_round::*;
+pub use update_project::*;
+pub use extend_pool_duration::*;

--- a/programs/stockpile-v2/src/instructions/update_project.rs
+++ b/programs/stockpile-v2/src/instructions/update_project.rs
@@ -1,0 +1,51 @@
+use anchor_lang::prelude::*;
+
+use crate::{state::project::*, error::ProtocolError};
+
+/// Updates a project, given a specific field
+pub fn update_project(
+    ctx: Context<UpdateProject>,
+    _project_id: u64,
+    update_field: UpdateField,
+) -> Result<()> {
+    let payer_key = &mut ctx.accounts.payer.key();
+    let project = &mut ctx.accounts.project;
+
+    require!(project.admins.contains(&payer_key), ProtocolError::NotAuthorized);
+
+    match update_field {
+        UpdateField::Name(new_name) => project.name = new_name,
+        UpdateField::Goal(new_goal) => project.goal = new_goal,
+        UpdateField::AddAdmin(new_admin) => {
+            if !project.admins.contains(&new_admin) {
+                project.admins.push(new_admin);
+            }
+        },
+        UpdateField::RemoveAdmin(admin_to_remove) => {
+            project.admins.retain(|&admin| admin != admin_to_remove);
+        },
+        UpdateField::Beneficiary(new_beneficiary) => project.beneficiary = new_beneficiary,
+        UpdateField::Status(new_status) => project.status = new_status,
+    };
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(
+    _project_id: u64,
+)]
+pub struct UpdateProject<'info> {
+    #[account(
+        mut,
+        seeds = [
+            Project::SEED_PREFIX.as_bytes(),
+            _project_id.to_le_bytes().as_ref(),
+        ],
+        bump = project.bump,
+    )]
+    pub project: Account<'info, Project>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}

--- a/programs/stockpile-v2/src/lib.rs
+++ b/programs/stockpile-v2/src/lib.rs
@@ -38,6 +38,7 @@ pub mod util;
 
 pub use instructions::*;
 use crate::state::pool::*;
+use crate::state::project::*;
 
 use solana_security_txt::security_txt;
 
@@ -183,5 +184,21 @@ pub mod stockpile_v2 {
         _pool_id: u64
     ) -> Result<()> {
         instructions::withdraw_funds_from_round(ctx, _pool_id)
+    }
+
+    pub fn update_project(
+        ctx: Context<UpdateProject>,
+        _project_id: u64,
+        update: UpdateField,
+    ) -> Result<()> {
+        instructions::update_project(ctx, _project_id, update)
+    }
+
+    pub fn extend_pool_duration(
+        ctx: Context<ExtendPool>,
+        _pool_id: u64,
+        new_end_date: u64,
+    ) -> Result<()> {
+        instructions::extend_pool_duration(ctx, _pool_id, new_end_date)
     }
 }

--- a/programs/stockpile-v2/src/state/pool.rs
+++ b/programs/stockpile-v2/src/state/pool.rs
@@ -155,6 +155,16 @@ impl Pool {
         Ok(())
     }
 
+    pub fn extend_pool_duration(&mut self, new_end: u64) -> Result<()> {
+        if new_end < self.end {
+            return Err(ProtocolError::ExtendDateInvalid.into());
+        }
+
+        self.end = new_end;
+
+        Ok(())
+    }
+
     /// Updates all shares using the Quadratic Funding algorithm
     pub fn update_shares(
         &mut self,

--- a/programs/stockpile-v2/src/state/project.rs
+++ b/programs/stockpile-v2/src/state/project.rs
@@ -72,3 +72,13 @@ impl Default for ProjectStatus {
         ProjectStatus::Active
     }
 }
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub enum UpdateField {
+    Name(String),
+    Goal(u64),
+    AddAdmin(Pubkey),
+    RemoveAdmin(Pubkey),
+    Beneficiary(Pubkey),
+    Status(ProjectStatus),
+}

--- a/programs/stockpile-v2/src/util.rs
+++ b/programs/stockpile-v2/src/util.rs
@@ -11,8 +11,8 @@ pub const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 pub const USDC_DEVNET_MINT: &str = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 
 pub const SOL_USD_PRICE_FEED_ID: &str = "ALP8SdU9oARYVLgLR7LrqMNCYBnhtnQz1cj6bwgwQmgj";
-// THIS IS DEVNET
-pub const USDC_USD_PRICE_FEED_ID: &str = "5SSkXsEKQepHHAewytPVwdej4epN1nxgLVM84L4KXgy7";
+// THIS IS MAINNET
+pub const USDC_USD_PRICE_FEED_ID: &str = "Gnt27xtC473ZT2Mw5u8wZ68Z3gULkSTb5DuxJy7eJotD";
 
 pub const SUPPORTED_SPL_MINTS: [&'static str; 2] = [USDC_MINT, USDC_DEVNET_MINT];
 


### PR DESCRIPTION
- Added two new instructions extend_pool_duration (which does what it says), and update_project (which also does what it says)
- Changed Pyth price feed IDs
- Add a "can_fund" util to the pool struct, for some more protocol level safety.